### PR TITLE
Permit usage of thecodingmachine/graphqlite ^4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /build/
 /phpunit.xml
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require" : {
     "php" : ">=7.1",
-    "thecodingmachine/graphqlite" : "~4.0.0",
+    "thecodingmachine/graphqlite" : "^4.0",
     "webonyx/graphql-php": "^0.13.1"
   },
   "require-dev": {


### PR DESCRIPTION
Hey there,
I've just updated your composer.json with ^4.0 in order to allow minor `4.1`. I saw that CI errored on PHP < 7.4. 
Any plans to drop these versions?